### PR TITLE
Added console startup with ctrl+c on runmultiple for validator number 1

### DIFF
--- a/hydrachain/app.py
+++ b/hydrachain/app.py
@@ -128,8 +128,9 @@ def runmultiple(ctx, num_validators, seed):
         n_config['data_dir'] += str(node_num)
         konfig.setup_data_dir(n_config['data_dir'])
 
-        # deactivate console (note: maybe this could work with one console)
-        n_config['deactivated_services'].append(Console.name)
+        # activate ipython console for the first validator
+        if not node_num == 0:
+            n_config['deactivated_services'].append(Console.name)
         # n_config['deactivated_services'].append(ChainService.name)
         apps.append(start_app(n_config, [account]))
     serve_until_stopped(apps)

--- a/hydrachain/app.py
+++ b/hydrachain/app.py
@@ -129,7 +129,7 @@ def runmultiple(ctx, num_validators, seed):
         konfig.setup_data_dir(n_config['data_dir'])
 
         # activate ipython console for the first validator
-        if not node_num == 0:
+        if node_num != 0:
             n_config['deactivated_services'].append(Console.name)
         # n_config['deactivated_services'].append(ChainService.name)
         apps.append(start_app(n_config, [account]))


### PR DESCRIPTION
Added the functionality to automatically run the IPython console for the 'runmultiple' option for the first validator (after pressing Ctrl+C and Return). The option to manually choose the validator seemed overkill..
