### PR TITLE
Fix import errors processblock.InvalidTransaction

### DIFF
--- a/hydrachain/app.py
+++ b/hydrachain/app.py
@@ -24,7 +24,6 @@ from pyethapp.accounts import mk_privkey
 from pyethapp.console_service import Console
 from pyethapp.db_service import DBService
 from pyethapp.jsonrpc import JSONRPCServer
-from pygelf.handlers import GelfUdpHandler
 
 from hydrachain import __version__
 from hydrachain.hdc_service import ChainService

--- a/hydrachain/hdc_service.py
+++ b/hydrachain/hdc_service.py
@@ -9,6 +9,7 @@ from ethereum.chain import Chain
 from ethereum.refcount_db import RefcountDB
 from ethereum.blocks import Block, VerificationFailed
 from ethereum.transactions import Transaction
+from ethereum import exceptions
 from devp2p.service import WiredService
 from ethereum import config as ethereum_config
 import gevent
@@ -296,7 +297,7 @@ class ChainService(eth_ChainService):
             log.debug('deserialized', elapsed='%.4fs' % elapsed, ts=time.time(),
                       gas_used=block.gas_used, gpsec=self.gpsec(block.gas_used, elapsed))
             assert block.header.check_pow()
-        except processblock.InvalidTransaction as e:
+        except exceptions.InvalidTransaction as e:
             log.warn('invalid transaction', block=t_block, error=e, FIXME='ban node')
             return
         except VerificationFailed as e:

--- a/hydrachain/native_contracts.py
+++ b/hydrachain/native_contracts.py
@@ -41,6 +41,7 @@ import ethereum.specials as specials
 import ethereum.utils as utils
 import ethereum.vm as vm
 from ethereum import slogging
+from ethereum import exceptions
 from ethereum.transactions import Transaction
 from ethereum.utils import encode_int, zpad, big_endian_to_int, int_to_big_endian
 
@@ -574,7 +575,7 @@ def test_call(block, sender, to, data='', gasprice=0, value=0):
 
     try:
         success, output = processblock.apply_transaction(test_block, tx)
-    except processblock.InvalidTransaction as e:
+    except exceptions.InvalidTransaction as e:
         success = False
     assert block.state_root == state_root_before
     if success:


### PR DESCRIPTION
`InvalidTransaction` is no longer defined in `processblock`, but in `exceptions` instead.
Also removed an obsolete import (probably a left-over after debugging).
