### PR TITLE
Fix toplevel docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,10 @@ RUN apt-get update &&\
 WORKDIR /
 ADD . hydrachain
 
-RUN pip install -U setuptools
+RUN pip install --upgrade pip setuptools
+
 # Pre-install hydrachain dependency
-RUN pip install secp256k1==0.12.1
+RUN pip install secp256k1==0.13.2
 
 WORKDIR /hydrachain
 # Reset potentially dirty directory and remove after install
@@ -19,4 +20,6 @@ RUN git reset --hard && pip install . && cd .. && rm -rf /hydrachain
 WORKDIR /
 
 ENTRYPOINT ["/usr/local/bin/hydrachain"]
-CMD ["run"]
+
+# Run multiple nodes in a single process
+CMD ["-d", "datadir", "runmultiple", "--num_validators=3", "--seed=42"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
 bitcoin>=1.1.39
 rlp>=0.4.3
-pyethapp>=1.2.1
-secp256k1==0.12.1
+pyethapp==1.5.0
+secp256k1==0.13.2
 simpy==3.0.8
+
+# Added to get upstream pyethapp working
+pyelliptic==1.5.7
+ethereum>=1.5.1,<2.0


### PR DESCRIPTION
Hi there,

I had issues getting hydrachain building, so I had to make some changes to the (toplevel) `Dockerfile` and `requirements.txt`.

Additionally, I changed `CMD` so that `docker run` will start multiple nodes in a single process by default (I was getting [this error](https://gist.github.com/bts/0951311d40466f6bb735e970537f5f06) with the default `CMD` of `["run"]`.)

Let me know if there's anything else you'd like me to change.

Thanks!
Brian